### PR TITLE
fix: use media channel instead of alarm

### DIFF
--- a/app/src/main/java/com/apps/adrcotfas/burpeebuddy/common/soundplayer/SoundPlayer.java
+++ b/app/src/main/java/com/apps/adrcotfas/burpeebuddy/common/soundplayer/SoundPlayer.java
@@ -14,7 +14,7 @@ public class SoundPlayer extends ContextWrapper {
 
     public void play(int sound) {
         AudioAttributes attributes = new AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_ALARM)
+                .setUsage(AudioAttributes.USAGE_MEDIA)
                 .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                 .build();
         SoundPool soundPool = new SoundPool.Builder()


### PR DESCRIPTION
To me, it feels better to use the media channel instead of alarm, which allows for more volume control (also allowing it to be turned off completely).